### PR TITLE
Don't waste time searching for patterns containing [01]

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+Changed from shallot-0.0.3 to shallot-0.0.4:
+
+* Check the search pattern for valid onion addresses.
+* Clean up some valgrind warnings (for unimportant things).
+
+
 Changed from shallot-0.0.2 to shallot-0.0.3:
 
 * Fixed some memory leaks.

--- a/src/defines.h
+++ b/src/defines.h
@@ -5,7 +5,7 @@
 #include <inttypes.h>
 
 // our ever-important version string
-#define VERSION "0.0.3-alpha"
+#define VERSION "0.0.4"
 
 // default values
 #define DEFAULT_THREADS 1 // not used on anything but unknown systems

--- a/src/error.c
+++ b/src/error.c
@@ -49,7 +49,7 @@ void error(int32_t code) {
     }
 
     case X_REGEX_INVALID: {
-      fprintf(stderr, "ERROR: Pattern cannot contain '-'.\n");
+      fprintf(stderr, "ERROR: Pattern cannot start with '-'.\n");
       break;
     }
 

--- a/src/error.c
+++ b/src/error.c
@@ -43,6 +43,11 @@ void error(int32_t code) {
       break;
     }
 
+    case X_REGEX_CHARS: {
+      fprintf(stderr, "ERROR: Bad pattern; must be [a-z2-7]!\n");
+      break;
+    }
+
     case X_REGEX_INVALID: {
       fprintf(stderr, "ERROR: Pattern cannot contain '-'.\n");
       break;

--- a/src/error.h
+++ b/src/error.h
@@ -22,7 +22,7 @@
 #define X_DAEMON_FAILED 0x0E
 #define X_OUT_OF_MEMORY 0x11
 #define X_MAXTIME_REACH 0x12
-
+#define X_REGEX_CHARS   0x13
 
 #ifdef BSD
   // BSD specific defines

--- a/src/print.c
+++ b/src/print.c
@@ -68,6 +68,7 @@ void print_prkey(RSA *rsa) { // print PEM formatted RSA key
   strncpy(dst, buf->data, buf->length);
   dst[buf->length] = '\0';
   printf("%s", dst);
+  free(dst);
   BUF_MEM_free(buf);
 }
 

--- a/src/shallot.c
+++ b/src/shallot.c
@@ -1,5 +1,5 @@
 /* program: shallot (based on the popular onionhash program by Bebop)
- * version: 0.0.2
+ * version: 0.0.4
  * purpose: brute-force customized SHA1-hashes of RSA keys for Tor's
  *          .onion namespace
  * license: OSI-approved MIT License

--- a/src/thread.c
+++ b/src/thread.c
@@ -80,11 +80,15 @@ void *worker(void *params) { // life cycle of a cracking pthread
         if(monitor)
           printf("\n"); // keep our printing pretty!
 
-        if(!BN_bin2bn(e_ptr, e_bytes, rsa->e)) // store our e in the actual key
-          error(X_BIGNUM_FAILED);              // and make sure it got there
+        if(!BN_bin2bn(e_ptr, e_bytes, rsa->e)) { // store our e in the actual key
+          RSA_free(rsa);                         // and make sure it got there
+          error(X_BIGNUM_FAILED);
+        }
 
-        if(!sane_key(rsa))        // check our key
+        if(!sane_key(rsa)) {      // check our key
+          RSA_free(rsa);
           error(X_YOURE_UNLUCKY); // bad key :(
+        }
 
         print_onion(onion); // print our domain
         print_prkey(rsa);   // and more importantly the key


### PR DESCRIPTION
After spending a few days searching for a six-character pattern, I dug into why it was taking orders of magnitude longer than expected. There wasn't any validation of the input pattern to ensure that my request could ever be found, so this is my attempt to add that.

Perhaps a future enhancement could be a warning message that prints after 2x as many loops have been completed as would be expected to find a match for the given string length, since my change isn't exhaustive. (It seems difficult, if not impossible, to write a regex to validate that an input regex meets the requirements for an .onion address, further limited by the lack of lookaround in POSIX regexes.)